### PR TITLE
OIDC tokens from Loginservice can be exchanged into SAML tokens

### DIFF
--- a/.nais/default-vars.yml
+++ b/.nais/default-vars.yml
@@ -13,6 +13,10 @@ envs:
     value: https://isso-q.adeo.no:443/isso/oauth2
   - name: APPLICATION_JWKS_ENDPOINT_OPENAM
     value: https://isso-q.adeo.no/isso/oauth2/connect/jwk_uri
+  - name: APPLICATION_EXTERNAL_ISSUER_AZUREB2C
+    value: https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/
+  - name: APPLICATION_JWKS_ENDPOINT_AZUREB2C
+    value: https://navtestb2c.b2clogin.com/navtestb2c.onmicrosoft.com/discovery/v2.0/keys?p=b2c_1a_idporten_ver1
   - name: APPLICATION_EXTERNAL_ISSUER_AZUREAD
     value: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0
   - name: APPLICATION_JWKS_ENDPOINT_AZUREAD

--- a/.nais/prod-vars.yml
+++ b/.nais/prod-vars.yml
@@ -12,6 +12,10 @@ envs:
     value: https://isso.adeo.no:443/isso/oauth2
   - name: APPLICATION_JWKS_ENDPOINT_OPENAM
     value: https://isso.adeo.no/isso/oauth2/connect/jwk_uri
+  - name: APPLICATION_EXTERNAL_ISSUER_AZUREB2C
+    value: https://navnob2c.b2clogin.com/8b7dfc8b-b52e-4741-bde4-d83ea366f94f/v2.0/
+  - name: APPLICATION_JWKS_ENDPOINT_AZUREB2C
+    value: https://navnob2c.b2clogin.com/navnob2c.onmicrosoft.com/discovery/v2.0/keys?p=b2c_1a_idporten
   - name: APPLICATION_EXTERNAL_ISSUER_AZUREAD
     value: https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b/v2.0
   - name: APPLICATION_JWKS_ENDPOINT_AZUREAD

--- a/.nais/t4-vars.yml
+++ b/.nais/t4-vars.yml
@@ -12,6 +12,10 @@ envs:
     value: https://isso-t.adeo.no:443/isso/oauth2
   - name: APPLICATION_JWKS_ENDPOINT_OPENAM
     value: https://isso-t.adeo.no/isso/oauth2/connect/jwk_uri
+  - name: APPLICATION_EXTERNAL_ISSUER_AZUREB2C
+    value: https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/
+  - name: APPLICATION_JWKS_ENDPOINT_AZUREB2C
+    value: https://navtestb2c.b2clogin.com/navtestb2c.onmicrosoft.com/discovery/v2.0/keys?p=b2c_1a_idporten_ver1
   - name: APPLICATION_EXTERNAL_ISSUER_AZUREAD
     value: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0
   - name: APPLICATION_JWKS_ENDPOINT_AZUREAD

--- a/.nais/test-vars.yml
+++ b/.nais/test-vars.yml
@@ -12,6 +12,10 @@ envs:
     value: https://isso-t.adeo.no:443/isso/oauth2
   - name: APPLICATION_JWKS_ENDPOINT_OPENAM
     value: https://isso-t.adeo.no/isso/oauth2/connect/jwk_uri
+  - name: APPLICATION_EXTERNAL_ISSUER_AZUREB2C
+    value: https://navtestb2c.b2clogin.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/
+  - name: APPLICATION_JWKS_ENDPOINT_AZUREB2C
+    value: https://navtestb2c.b2clogin.com/navtestb2c.onmicrosoft.com/discovery/v2.0/keys?p=b2c_1a_idporten_ver1
   - name: APPLICATION_EXTERNAL_ISSUER_AZUREAD
     value: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0
   - name: APPLICATION_JWKS_ENDPOINT_AZUREAD

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For local Development `https://security-token-service.dev.adeo.no` is exposed in
 | client_credentials        | OIDC                | `/rest/v1/sts/token2`                   | For Stormaskin   |
 | client_credentials          | SAML               |  `/rest/v1/sts/samltoken`             | 
 | OIDC (Issued by OpenAm, `This` STS, AzureAD)      |  SAML     | `/rest/v1/sts/token/exchange`                   |                          |
-| SAML token (Issued by STS(Datapower) or `This` STS)                   | OIDC     | `/rest/v1/sts/token/exchange`                   |           |
+| SAML token (Issued by STS(Datapower) Azure B2C (Loginservice) or `This` STS)                   | OIDC     | `/rest/v1/sts/token/exchange`                   |           |
 
 ### Example Request. For more info check out: `../api`
 `../rest/v1/sts/token`  
@@ -79,7 +79,6 @@ Content-Type: application/json
 }
 ```
 
-**Failed Response:**
 ```http
 HTTP/1.1 400 BadRequest
 Content-Type: application/json
@@ -124,6 +123,7 @@ Content-Type: application/json
 }
 ```
 
+**Failed Response:**
 ```http
 HTTP/1.1 400 BadRequest
 Content-Type: application/json
@@ -170,6 +170,7 @@ Content-Type: application/json
 }
 ```
 
+**Failed Response:**
 ```http
 HTTP/1.1 400 BadRequest
 Content-Type: application/json

--- a/src/main/kotlin/no/nav/gandalf/accesstoken/AccessTokenIssuer.kt
+++ b/src/main/kotlin/no/nav/gandalf/accesstoken/AccessTokenIssuer.kt
@@ -56,6 +56,10 @@ class AccessTokenIssuer(
                 externalIssuersConfig.jwksEndpointOpenAm
             ),
             OidcIssuerImpl(
+                externalIssuersConfig.issuerAzureB2C,
+                externalIssuersConfig.jwksEndpointAzureB2C
+            ),
+            OidcIssuerImpl(
                 externalIssuersConfig.issuerAzureAd,
                 externalIssuersConfig.jwksEndpointAzuread
             ),

--- a/src/main/kotlin/no/nav/gandalf/config/ExternalIssuer.kt
+++ b/src/main/kotlin/no/nav/gandalf/config/ExternalIssuer.kt
@@ -9,6 +9,10 @@ data class ExternalIssuer(
     val issuerOpenAm: String,
     @Value("\${application.jwks.endpoint.openam}")
     val jwksEndpointOpenAm: String,
+    @Value("\${application.external.issuer.azureb2c}")
+    val issuerAzureB2C: String,
+    @Value("\${application.jwks.endpoint.openam.azureb2c}")
+    val jwksEndpointAzureB2C: String,
     @Value("\${application.external.issuer.azuread}")
     val issuerAzureAd: String,
     @Value("\${application.jwks.endpoint.azuread}")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,7 @@ application:
   external.issuer:
     openam: <FROM ENV. VARS>
     azuread: <FROM ENV. VARS>
+    azureb2c: <FROM ENV. VARS>
     configuration.difi:
       oidc: <FROM ENV. VARS>
       maskinporten: <FROM ENV. VARS>
@@ -48,6 +49,7 @@ application:
     endpoint:
       openam: <FROM ENV. VARS>
       azuread: <FROM ENV. VARS>
+      azureb2c: <FROM ENV. VARS>
 # Truststore & KeyStore
 nav:
   truststore:


### PR DESCRIPTION
Dette er et behov for "Din pensjon" (selvbetjening) i SBS, der brukere logger inn via Loginservice, og derfra trenger vi et SAML-token for å snakke med tjenester i bakkant.