### PR TITLE
chore: update kotlinter -> 3.10.0 requires: kotlin 16.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,9 +21,9 @@ object Version {
 plugins {
     application
     java
-    val kotlinVersion = "1.6.0"
+    val kotlinVersion = "1.6.20"
     kotlin("plugin.allopen") version kotlinVersion
-    id("org.jmailen.kotlinter") version "3.9.0"
+    id("org.jmailen.kotlinter") version "3.10.0"
     id("com.github.ben-manes.versions") version "0.42.0"
     id("org.springframework.boot") version "2.6.6"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion


### PR DESCRIPTION
according to: https://github.com/jeremymailen/kotlinter-gradle/issues/248