### PR TITLE
Migrate from Spring Boot 3.5.7 to 4.0.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,9 +14,8 @@ val mockOAuth2Server = "3.0.1"
 val nimbus = "11.31.1"
 val openapi = "2.8.14"
 val unboundid = "7.0.4"
-val wiremockCloud = "4.3.0"
+val wiremockCloud = "3.13.2"
 val h2 = "2.4.240"
-val jacksonDatatype = "2.19.2"
 val conscrypt = "2.5.2"
 val prometheus = "1.12.5"
 val commonsLang = "3.20.0"
@@ -33,7 +32,7 @@ plugins {
     kotlin("plugin.allopen") version kotlinVersion
     id("org.jlleitschuh.gradle.ktlint") version "14.1.0"
     id("com.github.ben-manes.versions") version "0.53.0"
-    id("org.springframework.boot") version "3.5.7"
+    id("org.springframework.boot") version "4.0.6"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("io.spring.dependency-management") version "1.1.7"
@@ -52,11 +51,8 @@ repositories {
 dependencies {
     implementation("ch.qos.logback:logback-classic:$logbackClassic")
     implementation("ch.qos.logback:logback-core:$logbackClassic")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonDatatype")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDatatype")
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonDatatype")
-    implementation("com.fasterxml.jackson.core:jackson-core:$jacksonDatatype")
-    implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonDatatype")
+    implementation("tools.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("com.google.code.gson:gson")
     implementation("com.nimbusds:oauth2-oidc-sdk:$nimbus")
     implementation("com.unboundid:unboundid-ldapsdk:$unboundid")
@@ -88,11 +84,21 @@ dependencies {
         exclude(module = "junit")
     }
     testImplementation("org.springframework.security:spring-security-test:$springSecurity")
-    testImplementation("org.springframework.cloud:spring-cloud-contract-wiremock:$wiremockCloud")
+    testImplementation("org.wiremock:wiremock-jetty12:$wiremockCloud")
+    testImplementation("org.apache.httpcomponents.client5:httpclient5:5.4.4")
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("io.kotest:kotest-assertions-core:$kotest")
     testImplementation("io.mockk:mockk:$mockk")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group.startsWith("org.eclipse.jetty")) {
+            useVersion("12.1.8")
+            because("Align all Jetty modules to Spring Boot 4 managed version")
+        }
+    }
 }
 
 tasks {
@@ -115,6 +121,7 @@ tasks {
         }
     }
     withType<Test> {
+        useJUnitPlatform()
         testLogging {
             events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
         }

--- a/src/main/kotlin/no/nav/gandalf/api/CustomExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/gandalf/api/CustomExceptionHandler.kt
@@ -16,7 +16,7 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
     fun handleAllExceptions(
         ex: Exception,
         request: WebRequest?,
-    ): ResponseEntity<Any?> {
+    ): ResponseEntity<Any> {
         val error = ErrorDescriptiveResponse("Server Error", ex.localizedMessage)
         return ResponseEntity(error, HttpStatus.INTERNAL_SERVER_ERROR)
     }
@@ -25,7 +25,7 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
     fun handleLdapError(
         ex: LDAPException,
         request: WebRequest?,
-    ): ResponseEntity<Any?> {
+    ): ResponseEntity<Any> {
         val error = ErrorDescriptiveResponse(INVALID_CLIENT, ex.localizedMessage)
         return ResponseEntity(error, HttpStatus.UNAUTHORIZED)
     }

--- a/src/main/kotlin/no/nav/gandalf/config/GsonConfig.kt
+++ b/src/main/kotlin/no/nav/gandalf/config/GsonConfig.kt
@@ -1,0 +1,11 @@
+package no.nav.gandalf.config
+
+import com.google.gson.GsonBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GsonConfig {
+    @Bean
+    fun gsonBuilder(): GsonBuilder = GsonBuilder()
+}

--- a/src/main/kotlin/no/nav/gandalf/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nav/gandalf/config/SecurityConfig.kt
@@ -24,7 +24,7 @@ class SecurityConfig(
     @Bean
     fun ldapAuthenticationManager(): AuthenticationManager =
         AuthenticationManager { authentication ->
-            activeDirectoryLdapAuthenticationProvider().authenticate(authentication)
+            activeDirectoryLdapAuthenticationProvider().authenticate(authentication)!!
         }
 
     @Bean

--- a/src/main/kotlin/no/nav/gandalf/keystore/KeyStoreReader.kt
+++ b/src/main/kotlin/no/nav/gandalf/keystore/KeyStoreReader.kt
@@ -100,12 +100,14 @@ class KeyStoreReader(
     }
 
     fun numberOfDaysUtilCertificateExpire(): Double {
-        val days = ChronoUnit.DAYS.between(
-            LocalDate.now(),
-            LocalDate.parse(
-                SimpleDateFormat("yyyy-MM-dd").format(cert?.notAfter),
-            ),
-        ).toDouble()
+        val days =
+            ChronoUnit.DAYS
+                .between(
+                    LocalDate.now(),
+                    LocalDate.parse(
+                        SimpleDateFormat("yyyy-MM-dd").format(cert?.notAfter),
+                    ),
+                ).toDouble()
         log.debug { "Signing certificate expires in: $days" }
         return if (days > 0) days else 1.0
     }

--- a/src/main/kotlin/no/nav/gandalf/ldap/RestAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/no/nav/gandalf/ldap/RestAuthenticationEntryPoint.kt
@@ -1,6 +1,5 @@
 package no.nav.gandalf.ldap
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.ServletException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -10,6 +9,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
 import java.io.IOException
 import java.io.OutputStream
 
@@ -17,11 +17,11 @@ import java.io.OutputStream
 class RestAuthenticationEntryPoint : AuthenticationEntryPoint {
     @Throws(IOException::class, ServletException::class)
     override fun commence(
-        httpServletRequest: HttpServletRequest?,
+        httpServletRequest: HttpServletRequest,
         httpServletResponse: HttpServletResponse,
-        e: AuthenticationException?,
+        e: AuthenticationException,
     ) {
-        val response = ErrorDescriptiveResponse(INVALID_CLIENT, "Unauthorised: ${e?.message ?: ""}")
+        val response = ErrorDescriptiveResponse(INVALID_CLIENT, "Unauthorised: ${e.message ?: ""}")
         httpServletResponse.status = HttpStatus.UNAUTHORIZED.value()
         httpServletResponse.contentType = "application/json"
         val out: OutputStream = httpServletResponse.outputStream

--- a/src/test/kotlin/no/nav/gandalf/SpringBootWireMockSetup.kt
+++ b/src/test/kotlin/no/nav/gandalf/SpringBootWireMockSetup.kt
@@ -19,15 +19,19 @@ import no.nav.gandalf.utils.OPENAM_JWKS_URL
 import no.nav.gandalf.utils.OPENAM_RESPONSE_FILENAME
 import no.nav.gandalf.utils.endpointStub
 import no.nav.gandalf.utils.wellKnownStub
-import org.apache.http.HttpStatus
-import org.junit.Before
-import org.junit.runner.RunWith
+import org.apache.hc.core5.http.HttpStatus
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @SpringBootTest(
     properties = [
         "$PROP_EXTERNAL_PREFIX.difi.oidc=$WIREMOCK_URL$DIFI_CONFIG_URL",
@@ -37,15 +41,27 @@ import org.springframework.test.context.junit4.SpringRunner
         "$PROP_JWKS_ENDPOINT_PREFIX.azureb2c=$WIREMOCK_URL$AZUREAD_JWKS_URL",
         "$PROP_JWKS_ENDPOINT_PREFIX.openam=$WIREMOCK_URL$OPENAM_JWKS_URL",
     ],
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
 )
-@AutoConfigureWireMock(port = 0)
+@ContextConfiguration(initializers = [WireMockInitializer::class])
 abstract class SpringBootWireMockSetup {
     @Autowired
     private lateinit var server: WireMockServer
 
-    @Before
+    @Autowired
+    protected lateinit var wac: WebApplicationContext
+
+    protected lateinit var mvc: MockMvc
+
+    @BeforeEach
     fun setupKnownIssuers() {
+        mvc =
+            MockMvcBuilders
+                .webAppContextSetup(wac)
+                .apply<org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder>(SecurityMockMvcConfigurers.springSecurity())
+                .build()
+        server.resetAll()
+        server.resetAll()
         wellKnownStub(DIFI_CONFIG_URL, server.url(DIFI_JWKS_URL), DIFI_CONFIG_FILENAME)
         wellKnownStub(
             DIFI_MASKINPORTEN_CONFIG_URL,

--- a/src/test/kotlin/no/nav/gandalf/WireMockInitializer.kt
+++ b/src/test/kotlin/no/nav/gandalf/WireMockInitializer.kt
@@ -1,0 +1,19 @@
+package no.nav.gandalf
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import org.springframework.boot.test.util.TestPropertyValues
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+
+class WireMockInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+    override fun initialize(applicationContext: ConfigurableApplicationContext) {
+        val server = WireMockServer(wireMockConfig().dynamicPort()).also { it.start() }
+        applicationContext.beanFactory.registerSingleton("wireMockServer", server)
+        WireMock.configureFor("localhost", server.port())
+        TestPropertyValues
+            .of("wiremock.server.port=${server.port()}")
+            .applyTo(applicationContext.environment)
+    }
+}

--- a/src/test/kotlin/no/nav/gandalf/accesstoken/AccessTokenIssuerTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/accesstoken/AccessTokenIssuerTest.kt
@@ -45,12 +45,11 @@ import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import java.time.Instant
@@ -59,7 +58,6 @@ import java.time.ZonedDateTime
 private const val ACCESS_TOKEN_TYPE = "bearer"
 
 @ActiveProfiles("test")
-@AutoConfigureMockMvc
 @DirtiesContext
 class AccessTokenIssuerTest : SpringBootWireMockSetup() {
     @Autowired
@@ -102,6 +100,7 @@ class AccessTokenIssuerTest : SpringBootWireMockSetup() {
     }
 
     @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
     fun `Validate OpenAm OIDC`() {
         val oidcToken: String = getOpenAmOIDC()
         assertDoesNotThrow {

--- a/src/test/kotlin/no/nav/gandalf/accesstoken/IssuerConfigTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/accesstoken/IssuerConfigTest.kt
@@ -3,7 +3,7 @@ package no.nav.gandalf.accesstoken
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldNotBe
 import no.nav.security.mock.oauth2.withMockOAuth2Server
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class IssuerConfigTest {
     @Test

--- a/src/test/kotlin/no/nav/gandalf/accesstoken/OIDCObjectTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/accesstoken/OIDCObjectTest.kt
@@ -2,6 +2,7 @@ package no.nav.gandalf.accesstoken
 
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jwt.SignedJWT
+import no.nav.gandalf.WireMockInitializer
 import no.nav.gandalf.accesstoken.oauth.OidcObject
 import no.nav.gandalf.service.RsaKeysProvider
 import no.nav.gandalf.utils.compare
@@ -10,21 +11,18 @@ import no.nav.gandalf.utils.getOriginalJwkSet
 import no.nav.gandalf.utils.getOriginalToken
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.ContextConfiguration
 import java.time.ZonedDateTime
 
-@RunWith(SpringRunner::class)
 @SpringBootTest
 @ActiveProfiles("test")
-@AutoConfigureWireMock(port = 0)
+@ContextConfiguration(initializers = [WireMockInitializer::class])
 @DirtiesContext
 class OIDCObjectTest {
     @Autowired

--- a/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
@@ -1,28 +1,26 @@
 package no.nav.gandalf.accesstoken
 
 import no.nav.gandalf.TestKeySelector
+import no.nav.gandalf.WireMockInitializer
 import no.nav.gandalf.accesstoken.saml.SamlObject
 import no.nav.gandalf.keystore.KeyStoreReader
 import no.nav.gandalf.utils.getAlteredSamlToken
 import no.nav.gandalf.utils.getSamlToken
 import org.junit.Assert
 import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.ContextConfiguration
 import java.time.ZonedDateTime
 import javax.xml.crypto.KeySelector
 
-@RunWith(SpringRunner::class)
 @SpringBootTest
 @ActiveProfiles("test")
-@AutoConfigureWireMock(port = 0)
+@ContextConfiguration(initializers = [WireMockInitializer::class])
 @DirtiesContext
 class SamlObjectTest {
     @Autowired

--- a/src/test/kotlin/no/nav/gandalf/api/AccessTokenControllerTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/AccessTokenControllerTest.kt
@@ -9,26 +9,19 @@ import no.nav.gandalf.utils.SCOPE
 import no.nav.gandalf.utils.TOKEN
 import no.nav.gandalf.utils.TOKEN2
 import no.nav.gandalf.utils.TOKEN_TYPE
-import org.junit.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.apache.hc.core5.http.message.BasicNameValuePair
+import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
-import wiremock.org.apache.hc.core5.http.message.BasicNameValuePair
 
-@AutoConfigureMockMvc
 @ActiveProfiles("test")
 @DirtiesContext
 class AccessTokenControllerTest : SpringBootWireMockSetup() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
     @PostConstruct
     fun setup() {
         val controllerUtil = ControllerUtil()

--- a/src/test/kotlin/no/nav/gandalf/api/IdentityProviderControllerTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/IdentityProviderControllerTest.kt
@@ -7,25 +7,18 @@ import no.nav.gandalf.utils.JWKS
 import no.nav.gandalf.utils.TOKEN
 import no.nav.gandalf.utils.WELL_KNOWN
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 
-@AutoConfigureMockMvc
 @ActiveProfiles("test")
 @DirtiesContext
 class IdentityProviderControllerTest : SpringBootWireMockSetup() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
     // Path: /jwks
     @Test
     fun `Get JWKS Should only return Public keys`() {

--- a/src/test/kotlin/no/nav/gandalf/api/TokenExchangeControllerTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/TokenExchangeControllerTest.kt
@@ -2,8 +2,7 @@ package no.nav.gandalf.api
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.OptBoolean
-import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.annotation.PostConstruct
 import no.nav.gandalf.SpringBootWireMockSetup
 import no.nav.gandalf.utils.ControllerUtil
@@ -21,30 +20,24 @@ import no.nav.gandalf.utils.TOKEN_SUBJECT
 import no.nav.gandalf.utils.TOKEN_TYPE
 import no.nav.gandalf.utils.getDifiOidcToken
 import no.nav.gandalf.utils.getOpenAmAndDPSamlExchangePair
-import no.nav.security.mock.oauth2.http.objectMapper
-import org.junit.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity
+import org.apache.hc.core5.http.io.entity.EntityUtils
+import org.apache.hc.core5.http.message.BasicNameValuePair
+import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
-import wiremock.org.apache.hc.client5.http.entity.UrlEncodedFormEntity
-import wiremock.org.apache.hc.core5.http.io.entity.EntityUtils
-import wiremock.org.apache.hc.core5.http.message.BasicNameValuePair
 
-@AutoConfigureMockMvc
+private val objectMapper = ObjectMapper()
+
 @ActiveProfiles("test")
 @DirtiesContext
 class TokenExchangeControllerTest : SpringBootWireMockSetup() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
     @PostConstruct
     fun setup() {
         val controllerUtil = ControllerUtil()
@@ -66,7 +59,7 @@ class TokenExchangeControllerTest : SpringBootWireMockSetup() {
                 .andExpect(jsonPath("$.access_token").isString)
                 .andReturn()
 
-        val mockedToken = objectMapper.readValue<MockTokenTest>(result.response.contentAsString)
+        val mockedToken = objectMapper.readValue(result.response.contentAsString, MockTokenTest::class.java)
 
         mvc
             .perform(
@@ -105,7 +98,7 @@ class TokenExchangeControllerTest : SpringBootWireMockSetup() {
                 .andExpect(jsonPath("$.access_token").isString)
                 .andReturn()
 
-        val mockedToken = objectMapper.readValue<MockTokenTest>(result.response.contentAsString)
+        val mockedToken = objectMapper.readValue(result.response.contentAsString, MockTokenTest::class.java)
 
         mvc
             .perform(
@@ -210,7 +203,7 @@ class TokenExchangeControllerTest : SpringBootWireMockSetup() {
                 .andExpect(jsonPath("$.expires_in").value(3600))
                 .andReturn()
 
-        val mockedToken = objectMapper.readValue<MockTokenTest>(result.response.contentAsString)
+        val mockedToken = objectMapper.readValue(result.response.contentAsString, MockTokenTest::class.java)
 
         mvc
             .perform(
@@ -293,6 +286,6 @@ internal fun MockHttpServletRequestBuilder.formPostBody(formBody: List<BasicName
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class MockTokenTest(
-    @JsonProperty("access_token", isRequired = OptBoolean.TRUE)
+    @JsonProperty("access_token")
     val access_token: String,
 )

--- a/src/test/kotlin/no/nav/gandalf/api/TokenInfoControllerTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/TokenInfoControllerTest.kt
@@ -1,6 +1,6 @@
 package no.nav.gandalf.api
 
-import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.gandalf.SpringBootWireMockSetup
 import no.nav.gandalf.utils.DATAPOWER_SAML_BASE64_ENCODED
 import no.nav.gandalf.utils.GRANT_TYPE
@@ -12,26 +12,20 @@ import no.nav.gandalf.utils.TOKEN
 import no.nav.gandalf.utils.TOKEN_SUBJECT
 import no.nav.gandalf.utils.TOKEN_TYPE
 import no.nav.gandalf.utils.getOpenAmOIDC
-import no.nav.security.mock.oauth2.http.objectMapper
-import org.junit.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 
-@AutoConfigureMockMvc
+private val objectMapper = ObjectMapper()
+
 @ActiveProfiles("test")
 @DirtiesContext
 class TokenInfoControllerTest : SpringBootWireMockSetup() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
     @Test
     fun `Validate Valid SAML Token`() {
         val result =
@@ -48,7 +42,7 @@ class TokenInfoControllerTest : SpringBootWireMockSetup() {
                 .andExpect(jsonPath("$.expires_in").isNumber)
                 .andReturn()
 
-        val mockedToken = objectMapper.readValue<MockTokenTest>(result.response.contentAsString)
+        val mockedToken = objectMapper.readValue(result.response.contentAsString, MockTokenTest::class.java)
 
         mvc
             .perform(
@@ -96,7 +90,7 @@ class TokenInfoControllerTest : SpringBootWireMockSetup() {
                 .andExpect(jsonPath("$.expires_in").value(3600))
                 .andReturn()
 
-        val mockedToken = objectMapper.readValue<MockTokenTest>(result.response.contentAsString)
+        val mockedToken = objectMapper.readValue(result.response.contentAsString, MockTokenTest::class.java)
 
         mvc
             .perform(

--- a/src/test/kotlin/no/nav/gandalf/api/WSSAMLTokenControllerTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/WSSAMLTokenControllerTest.kt
@@ -9,28 +9,22 @@ import no.nav.gandalf.utils.WS_SAMLTOKEN
 import no.nav.gandalf.utils.getOidcToSamlRequest
 import no.nav.gandalf.utils.getSamlRequest
 import no.nav.gandalf.utils.getValidateSamlRequest
-import org.apache.http.entity.ContentType
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.Date
 
-@AutoConfigureMockMvc
 @ActiveProfiles("test")
 @DirtiesContext
 class WSSAMLTokenControllerTest : SpringBootWireMockSetup() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
     @Autowired
     private lateinit var issuer: AccessTokenIssuer
 
@@ -42,7 +36,7 @@ class WSSAMLTokenControllerTest : SpringBootWireMockSetup() {
                 MockMvcRequestBuilders
                     .post(WS_SAMLTOKEN)
                     .with(SecurityMockMvcRequestPostProcessors.anonymous())
-                    .contentType(ContentType.TEXT_XML.mimeType)
+                    .contentType(MediaType.TEXT_XML)
                     .content(xmlReq),
             ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
             .andExpect(MockMvcResultMatchers.content().contentType("text/xml;charset=UTF-8"))
@@ -56,7 +50,7 @@ class WSSAMLTokenControllerTest : SpringBootWireMockSetup() {
                 MockMvcRequestBuilders
                     .post(WS_SAMLTOKEN)
                     .with(SecurityMockMvcRequestPostProcessors.anonymous())
-                    .contentType(ContentType.TEXT_XML.mimeType)
+                    .contentType(MediaType.TEXT_XML)
                     .content(xmlReq),
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.content().contentType("text/xml;charset=UTF-8"))
@@ -72,7 +66,7 @@ class WSSAMLTokenControllerTest : SpringBootWireMockSetup() {
                 MockMvcRequestBuilders
                     .post(WS_SAMLTOKEN)
                     .with(SecurityMockMvcRequestPostProcessors.anonymous())
-                    .contentType(ContentType.TEXT_XML.mimeType)
+                    .contentType(MediaType.TEXT_XML)
                     .content(xmlReq),
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.content().contentType("text/xml;charset=UTF-8"))
@@ -88,7 +82,7 @@ class WSSAMLTokenControllerTest : SpringBootWireMockSetup() {
                 MockMvcRequestBuilders
                     .post(WS_SAMLTOKEN)
                     .with(SecurityMockMvcRequestPostProcessors.anonymous())
-                    .contentType(ContentType.TEXT_XML.mimeType)
+                    .contentType(MediaType.TEXT_XML)
                     .content(xmlReq),
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.content().contentType("text/xml;charset=UTF-8"))
@@ -96,7 +90,7 @@ class WSSAMLTokenControllerTest : SpringBootWireMockSetup() {
         // .andExpect(MockMvcResultMatchers.xpath("/*/soapenv:Body/").exists())
     }
 
-    @Ignore("MockkStatic is disabled on newer java versions")
+    @Disabled("MockkStatic is disabled on newer java versions")
     @Test
     fun `exchange oidc from tokendings and idporten to SAML`() {
         val token = "eyJraWQiOiI3YmM4MjAxYS1lNDkxLTQxZDMtYjVlZC0zNTU1NjRjMjE4MDgiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdF9oYXNoIjoiY2ZCRFJuODFYSkJnUG9NWVZyd2JFZyIsInN1YiI6IlFGeUJvYW9HQ2ZYV2hLR0tyQzl5dkVnY2lyTzdFblktNjVCU1kteGNrdG89IiwiYW1yIjpbIkJhbmtJRCJdLCJpc3MiOiJodHRwczpcL1wvdG9rZW5kaW5ncy5kZXYtZ2NwLm5haXMuaW8iLCJwaWQiOiIwODA4OTQwNjMxNiIsImxvY2FsZSI6Im5iIiwiY2xpZW50X2lkIjoiZGV2LWdjcDpwbGF0dGZvcm1zaWtrZXJoZXQ6ZGVidWctZGluZ3MiLCJzaWQiOiJRUWxzWTk5Qi1nQ0lHSGEtWHpVVXpzdHl4VjE1d3UwZmdyamZ5ZG5OSTRzIiwiYXVkIjoiZGV2LWdjcDpwbGF0dGZvcm1zaWtrZXJoZXQ6YXBpLWRpbmdzIiwiYWNyIjoiTGV2ZWw0IiwibmJmIjoxNjI5ODAzNzAxLCJpZHAiOiJodHRwczpcL1wvb2lkYy12ZXIyLmRpZmkubm9cL2lkcG9ydGVuLW9pZGMtcHJvdmlkZXJcLyIsImF1dGhfdGltZSI6MTYyOTgwMzQ4OSwiZXhwIjoxNjI5ODA0MDAxLCJpYXQiOjE2Mjk4MDM3MDEsImp0aSI6ImY4OGRjZjFkLWNlNDgtNDUwYy05MWExLWQwZThiYzdhZDNiZiJ9.nn2lF8H_GjlSYr_s7Mx_QRJMzK-_kiGIAUSZ4UQ1uT89luJ8juJbYQHykbiHiQmIF0Z5TEPgFO4Irc9GcKFVbUDRmAB7ucthCD3WBjSK1MUec_qTdynEtq3CxJMC1Edag2XN0GQLNO4ENHa0hqb9eKzMMS19W8fTw9P3ONPK4A-oi7WqvYCsNfozKsPtNuBSm0MkqKMjlEpAoXvF-TgMvm-JW9wuI3Y4DkTq7n1v0MnMJxnJAQ7twZgBcSx2Ff4Ck0uPXcvICCuvvr6EcNmNgWtBWRNwD3acOpSN17b-Tt78CdK-9-lp_SqV0Cl0g5UBKtH_Ph2s4kmkc12oY2HqxA"
@@ -107,7 +101,7 @@ class WSSAMLTokenControllerTest : SpringBootWireMockSetup() {
                 MockMvcRequestBuilders
                     .post(WS_SAMLTOKEN)
                     .with(SecurityMockMvcRequestPostProcessors.anonymous())
-                    .contentType(ContentType.TEXT_XML.mimeType)
+                    .contentType(MediaType.TEXT_XML)
                     .content(xmlReq),
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.content().contentType("text/xml;charset=UTF-8"))

--- a/src/test/kotlin/no/nav/gandalf/api/WSTrustRequestTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/WSTrustRequestTest.kt
@@ -3,6 +3,7 @@ package no.nav.gandalf.api
 import com.nimbusds.jwt.SignedJWT
 import io.prometheus.client.CollectorRegistry
 import no.nav.gandalf.TestKeySelector
+import no.nav.gandalf.WireMockInitializer
 import no.nav.gandalf.accesstoken.AccessTokenIssuer
 import no.nav.gandalf.accesstoken.saml.SamlObject
 import no.nav.gandalf.utils.getOidcToSamlRequest
@@ -10,21 +11,18 @@ import no.nav.gandalf.utils.getSamlRequest
 import no.nav.gandalf.utils.getValidateSamlRequest
 import org.junit.After
 import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
-import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.ContextConfiguration
 
-@RunWith(SpringRunner::class)
 @SpringBootTest
 @EnableConfigurationProperties
-@AutoConfigureWireMock(port = 0)
+@ContextConfiguration(initializers = [WireMockInitializer::class])
 @DirtiesContext
 @ActiveProfiles("test")
 class WSTrustRequestTest {

--- a/src/test/kotlin/no/nav/gandalf/keystore/KeystoreConfigTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/keystore/KeystoreConfigTest.kt
@@ -1,7 +1,7 @@
 package no.nav.gandalf.keystore
 
 import no.nav.gandalf.config.KeystoreReaderConfig
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.core.io.ClassPathResource

--- a/src/test/kotlin/no/nav/gandalf/keystore/RsaKeysProviderTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/keystore/RsaKeysProviderTest.kt
@@ -3,21 +3,16 @@ package no.nav.gandalf.keystore
 import com.nimbusds.jose.jwk.RSAKey
 import jakarta.transaction.Transactional
 import no.nav.gandalf.service.RsaKeysProvider
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.util.AssertionErrors.assertEquals
 import org.springframework.test.util.AssertionErrors.assertTrue
 import org.springframework.transaction.PlatformTransactionManager
-import org.springframework.transaction.TransactionStatus
-import org.springframework.transaction.support.TransactionCallbackWithoutResult
 import org.springframework.transaction.support.TransactionTemplate
 
-@RunWith(SpringRunner::class)
 @SpringBootTest
 @ActiveProfiles("test")
 class RsaKeysProviderTest {
@@ -67,14 +62,10 @@ class RsaKeysProviderTest {
 
     private fun readKeysInTransaction() {
         val tmpl = TransactionTemplate(txManager!!)
-        tmpl.execute(
-            object : TransactionCallbackWithoutResult() {
-                override fun doInTransactionWithoutResult(status: TransactionStatus) {
-                    val key: RSAKey = provider!!.currentRSAKey
-                    println(key.toJSONString())
-                }
-            },
-        )
+        tmpl.execute {
+            val key: RSAKey = provider!!.currentRSAKey
+            println(key.toJSONString())
+        }
     }
 
     private fun startThreadsThatReadInSeparateTransaction(numberOfThreads: Int) {

--- a/src/test/kotlin/no/nav/gandalf/ldap/LdapTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/ldap/LdapTest.kt
@@ -5,13 +5,10 @@ import io.prometheus.client.CollectorRegistry
 import no.nav.gandalf.config.LdapConfig
 import no.nav.gandalf.model.User
 import org.junit.After
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.runner.RunWith
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.junit4.SpringRunner
 
-@RunWith(SpringRunner::class)
 @SpringBootTest
 class LdapTest {
     @After

--- a/src/test/kotlin/no/nav/gandalf/utils/AccessTokenIssuerTestUtil.kt
+++ b/src/test/kotlin/no/nav/gandalf/utils/AccessTokenIssuerTestUtil.kt
@@ -3,12 +3,10 @@ package no.nav.gandalf.utils
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor
-import org.apache.http.HttpStatus
+import org.apache.hc.core5.http.HttpStatus
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -28,7 +26,7 @@ internal const val DIFI_MASKINPORTEN_CONFIG_FILENAME = "difi-maskinporten-config
 internal const val AZUREAD_JWKS_FILENAME = "azuread-jwks.json"
 internal const val AZUREAD_JWKS_URL = "/discovery/v2.0/keys"
 
-private val objectMapper: ObjectMapper = jacksonObjectMapper()
+private val objectMapper: ObjectMapper = ObjectMapper()
 
 internal fun endpointStub(
     status: Int = HttpStatus.SC_OK,
@@ -52,7 +50,7 @@ internal fun wellKnownStub(
 ) {
     val content = Files.readString(Path.of("src/test/resources/__files/$bodyFile"))
     val jsonNode: JsonNode =
-        objectMapper.readValue<JsonNode>(content).apply {
+        objectMapper.readValue(content, JsonNode::class.java).apply {
             (this as ObjectNode).put("jwks_uri", jwksUrl)
         }
     endpointStubWithBody(path = path, body = jsonNode)

--- a/src/test/kotlin/no/nav/gandalf/utils/WSTrustRequestTestUtil.kt
+++ b/src/test/kotlin/no/nav/gandalf/utils/WSTrustRequestTestUtil.kt
@@ -1,6 +1,6 @@
 package no.nav.gandalf.utils
 
-import wiremock.org.apache.commons.codec.binary.Base64
+import java.util.Base64
 
 internal fun getOidcToSamlRequest(
     brukerNavn: String,
@@ -27,7 +27,7 @@ internal fun getOidcToSamlRequest(
 internal fun getWrappedOidcToken(oidcToken: String) =
     (
         "<wsse:BinarySecurityToken EncodingType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary\" ValueType=\"urn:ietf:params:oauth:token-type:jwt\">" +
-            Base64.encodeBase64URLSafeString(oidcToken.toByteArray()) +
+            Base64.getUrlEncoder().withoutPadding().encodeToString(oidcToken.toByteArray()) +
             "</wsse:BinarySecurityToken>"
     )
 


### PR DESCRIPTION
# Migrate Spring Boot 3.5.7 → 4.0.6

Spring Boot 4.0.6 ships Spring Framework 7, Spring Security 7, and Jetty 12.1.x — each with breaking API changes that required updating both production and test code.
What changed

## Production code
- ResponseEntity<Any?> → <Any> (non-nullable bound in Spring Framework 7)
- authenticate() return made non-null; commence() params made non-nullable
- GsonBuilder registered as an explicit @Bean (no longer auto-configured)
- Jackson: switched to tools.jackson.module:jackson-module-kotlin (3.x); annotations and jackson-datatype-jsr310 remain under com.fasterxml; versions managed by BOM

## Test infrastructure
- Replaced spring-cloud-contract-wiremock with org.wiremock:wiremock-jetty12 + httpclient5; forced all Jetty modules to 12.1.8 via Gradle resolution strategy
- Replaced @AutoConfigureWireMock with a custom WireMockInitializer (ApplicationContextInitializer) that calls WireMock.configureFor() so static stubFor()/verify() target the right server
- Replaced @AutoConfigureMockMvc with MockMvcBuilders.webAppContextSetup() + springSecurity() built in @BeforeEach on the base class
- Full JUnit 4 → JUnit 5 migration: @Test, @BeforeEach, @Disabled, useJUnitPlatform()
- SpringRunner → SpringExtension; TransactionCallbackWithoutResult → lambda
- Fixed jacksonObjectMapper(), readValue<T>() extension, Apache HttpClient 4 → 5 imports, shaded Base64 → java.util.Base64
- Added @DirtiesContext(BEFORE_METHOD) on one test to prevent JWKS cache bleed between tests