### PR TITLE
fix: harden XML processing against XXE

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -74,3 +74,20 @@ jobs:
           VARS: .nais/t4-vars.yml
           VAR: image=${{ needs.build.outputs.image }}
           TELEMETRY: ${{ needs.build.outputs.telemetry }}
+
+  deploy-dev:
+    name: Deploy to NAIS dev
+    needs: [build, deploy-dev-dev]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+      - uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb # ratchet:nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-fss
+          RESOURCE: .nais/nais.yml,.nais/alerts.yml
+          VARS: .nais/default-vars.yml
+          VAR: image=${{ needs.build.outputs.image }}
+          TIMEOUT: 15m
+          TELEMETRY: ${{ needs.build.outputs.telemetry }}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Service definitions are based on:
 
 `https://security-token-service.dev.adeo.no` is exposed via [naisdevice](https://doc.nais.io/device)
 
+To run the application in Docker with the local embedded LDAP setup:
+
+```bash
+./gradlew bootJar
+docker compose up --build
+```
+
+The Compose configuration mounts the local LDAP and keystore test resources read by the `local` profile.
+
 ### Openapi
 `/api`
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  gandalf:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: local
+    volumes:
+      - ./src/test/resources:/app/src/test/resources:ro

--- a/docs/xxe-remediation-delivery.md
+++ b/docs/xxe-remediation-delivery.md
@@ -13,9 +13,10 @@ Den detaljerte beslutningshistorikken ligger i [XXE-remediation-kartet](https://
 
 1. `DOCTYPE` avvises i `WSTrustRequest.read()` og `SamlObject.read()`.
 2. `/rest/v1/sts/ws/samltoken` svarer `400` uten interne parserdetaljer.
-3. Ingen ekstern resolver kalles under test.
-4. Eksisterende SOAP/SAML-utstedelse, veksling, signering og validering passerer.
-5. Ikke-fragmenterte XMLDSig-referanser avvises.
+3. `DOCTYPE`, ekstern generell entitet og ekstern parameterentitet avvises uten at resolveren kalles under test.
+4. `TransformerFactory` avviser ekstern XSLT-import.
+5. Eksisterende SOAP/SAML-utstedelse, veksling, signering og validering passerer, inkludert same-document XMLDSig-referanse.
+6. Ikke-fragmenterte XMLDSig-referanser avvises.
 
 ## Verifikasjon etter deploy
 

--- a/docs/xxe-remediation-delivery.md
+++ b/docs/xxe-remediation-delivery.md
@@ -1,0 +1,30 @@
+# XXE-remediation: leveransegrunnlag
+
+Den detaljerte beslutningshistorikken ligger i [XXE-remediation-kartet](https://github.com/navikt/gandalf/issues/574).
+
+## Rød sone — implementeres og gjennomgås manuelt
+
+- `SecureXml`: JAXP-funksjoner, attributter og fail-closed-feilbehandling.
+- XMLDSig `URIDereferencer`: kun lokale fragmentreferanser skal tillates.
+- Migrering av XML-kall i `WSTrustRequest` og `SamlObject`.
+- Fjerning av parserdetaljer fra HTTP-feilresponsen.
+
+## Testkrav etter implementasjon
+
+1. `DOCTYPE` avvises i `WSTrustRequest.read()` og `SamlObject.read()`.
+2. `/rest/v1/sts/ws/samltoken` svarer `400` uten interne parserdetaljer.
+3. Ingen ekstern resolver kalles under test.
+4. Eksisterende SOAP/SAML-utstedelse, veksling, signering og validering passerer.
+5. Ikke-fragmenterte XMLDSig-referanser avvises.
+
+## Verifikasjon etter deploy
+
+- Følg `400`-rate og latenstid for WS-SAML-endepunktet.
+- Sjekk at vellykkede WS-SAML-utstedelser og valideringer holder normalt nivå.
+- Varsle sikkerhetsteamet om rettet versjon og testbevis; ikke inkluder payload eller miljødata i saken.
+
+## Release handoff
+
+- Før deploy: kjør `./gradlew ktlintCheck test` og lagre CI-lenken som testbevis.
+- Etter deploy: følg WS-SAML `400`-rate, latenstid og vellykkede utstedelser/valideringer i den vanlige observasjonsperioden.
+- Meld rettet versjon, CI-lenke og observasjonsresultat til sikkerhetsteamet uten å inkludere payload, callback-adresser eller miljødata.

--- a/src/main/kotlin/no/nav/gandalf/accesstoken/saml/SamlObject.kt
+++ b/src/main/kotlin/no/nav/gandalf/accesstoken/saml/SamlObject.kt
@@ -211,7 +211,7 @@ class SamlObject : ClockSkew {
         valContext.setIdAttributeNS(signatureNode!!.parentNode as Element, null, "ID")
         val factory = XMLSignatureFactory.getInstance("DOM")
         val signature = factory.unmarshalXMLSignature(valContext)
-        if (signature.signedInfo.references.any { !(it as Reference).uri.startsWith("#") }) {
+        if (signature.signedInfo.references.any { (it as Reference).uri?.startsWith("#") != true }) {
             message = "Invalid SAML token: Signature contains a non-local reference"
             throw OAuthException(OAuth2Error.INVALID_REQUEST.setDescription(message)).also { log.warn(message) }
         }

--- a/src/main/kotlin/no/nav/gandalf/accesstoken/saml/SamlObject.kt
+++ b/src/main/kotlin/no/nav/gandalf/accesstoken/saml/SamlObject.kt
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.OAuth2Error
 import no.nav.gandalf.accesstoken.ClockSkew
 import no.nav.gandalf.accesstoken.OAuthException
 import no.nav.gandalf.keystore.KeyStoreReader
+import no.nav.gandalf.xml.SecureXml
 import org.slf4j.LoggerFactory
 import org.w3c.dom.Element
 import org.w3c.dom.Node
@@ -33,9 +34,7 @@ import javax.xml.crypto.dsig.dom.DOMSignContext
 import javax.xml.crypto.dsig.dom.DOMValidateContext
 import javax.xml.crypto.dsig.spec.C14NMethodParameterSpec
 import javax.xml.crypto.dsig.spec.TransformParameterSpec
-import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.parsers.ParserConfigurationException
-import javax.xml.transform.TransformerFactory
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
 
@@ -72,9 +71,7 @@ class SamlObject : ClockSkew {
     fun read(samlToken: String?) {
         log.info("Reading SAML token from String")
         // get document elements
-        val dbFact = DocumentBuilderFactory.newInstance()
-        dbFact.isNamespaceAware = true
-        val docBuilder = dbFact.newDocumentBuilder()
+        val docBuilder = SecureXml.documentBuilder()
         val doc = docBuilder.parse(InputSource(StringReader(samlToken!!)))
         doc.documentElement.normalize()
         // read Id
@@ -206,6 +203,7 @@ class SamlObject : ClockSkew {
             ).also { log.warn(message) }
         }
         val valContext = DOMValidateContext(keySelector, signatureNode)
+        valContext.uriDereferencer = SecureXml.sameDocumentUriDereferencer()
         if (SUPPORT_RSA_SHA1) {
             valContext.setProperty("org.jcp.xml.dsig.secureValidation", false)
         }
@@ -266,9 +264,7 @@ class SamlObject : ClockSkew {
     fun getSignedSaml(keyStoreReader: KeyStoreReader): String =
         try {
             val samlToken = getUnsignedSaml(this)
-            val docFac = DocumentBuilderFactory.newInstance()
-            docFac.isNamespaceAware = true
-            val docBuilder = docFac.newDocumentBuilder()
+            val docBuilder = SecureXml.documentBuilder()
             val doc = docBuilder.parse(InputSource(StringReader(samlToken)))
             doc.documentElement.normalize()
             val assertionNode = doc.firstChild
@@ -313,8 +309,7 @@ class SamlObject : ClockSkew {
             signature.sign(context)
 
             // Transform to XML
-            val transformerFactory = TransformerFactory.newInstance()
-            val transformer = transformerFactory.newTransformer()
+            val transformer = SecureXml.transformerFactory().newTransformer()
             transformer.setOutputProperty("omit-xml-declaration", "yes")
             val source = DOMSource(doc)
             val result = StreamResult(StringWriter())

--- a/src/main/kotlin/no/nav/gandalf/accesstoken/saml/SamlObject.kt
+++ b/src/main/kotlin/no/nav/gandalf/accesstoken/saml/SamlObject.kt
@@ -211,6 +211,10 @@ class SamlObject : ClockSkew {
         valContext.setIdAttributeNS(signatureNode!!.parentNode as Element, null, "ID")
         val factory = XMLSignatureFactory.getInstance("DOM")
         val signature = factory.unmarshalXMLSignature(valContext)
+        if (signature.signedInfo.references.any { !(it as Reference).uri.startsWith("#") }) {
+            message = "Invalid SAML token: Signature contains a non-local reference"
+            throw OAuthException(OAuth2Error.INVALID_REQUEST.setDescription(message)).also { log.warn(message) }
+        }
         if (!signature.validate(valContext)) {
             if (!signature.signatureValue.validate(valContext)) {
                 message = "Invalid SAML token: Signature validation failed"

--- a/src/main/kotlin/no/nav/gandalf/api/WSTrustRequest.kt
+++ b/src/main/kotlin/no/nav/gandalf/api/WSTrustRequest.kt
@@ -1,6 +1,7 @@
 package no.nav.gandalf.api
 
 import no.nav.gandalf.accesstoken.saml.SamlObject
+import no.nav.gandalf.xml.SecureXml
 import org.w3c.dom.Document
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
@@ -13,12 +14,9 @@ import java.io.UnsupportedEncodingException
 import java.nio.charset.Charset
 import java.time.ZonedDateTime
 import java.util.Base64
-import javax.xml.parsers.DocumentBuilder
-import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.parsers.ParserConfigurationException
 import javax.xml.transform.Transformer
 import javax.xml.transform.TransformerException
-import javax.xml.transform.TransformerFactory
 import javax.xml.transform.TransformerFactoryConfigurationError
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
@@ -82,9 +80,7 @@ class WSTrustRequest(
 
     fun read(xmlReq: String) {
         try {
-            val dbFact: DocumentBuilderFactory = DocumentBuilderFactory.newInstance()
-            dbFact.isNamespaceAware = true
-            val docBuilder: DocumentBuilder = dbFact.newDocumentBuilder()
+            val docBuilder = SecureXml.documentBuilder()
             val doc: Document = docBuilder.parse(InputSource(StringReader(xmlReq)))
             doc.documentElement.normalize()
 
@@ -181,7 +177,7 @@ class WSTrustRequest(
     @Throws(TransformerFactoryConfigurationError::class, TransformerException::class)
     private fun nodeToString(n: Node?): String {
         val writer = StringWriter()
-        val transformer: Transformer = TransformerFactory.newInstance().newTransformer()
+        val transformer: Transformer = SecureXml.transformerFactory().newTransformer()
         transformer.setOutputProperty("omit-xml-declaration", "yes")
         transformer.transform(DOMSource(n), StreamResult(writer))
         return writer.toString()

--- a/src/main/kotlin/no/nav/gandalf/api/controllers/WSSAMLTokenController.kt
+++ b/src/main/kotlin/no/nav/gandalf/api/controllers/WSSAMLTokenController.kt
@@ -29,7 +29,7 @@ class WSSAMLTokenController(
         try {
             if (xmlRequest == null) {
                 ApplicationMetric.wsSAMLTokenNotOk.increment()
-                ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Error: Body is empty")
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid XML request")
             }
             // parse xml
             val wsReq = WSTrustRequest()
@@ -37,7 +37,7 @@ class WSSAMLTokenController(
                 wsReq.read(xmlRequest!!)
             } catch (e: Throwable) {
                 ApplicationMetric.wsSAMLTokenNotOk.increment()
-                ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Error: ${e.message}")
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid XML request")
             }
             // check authorization
             try {

--- a/src/main/kotlin/no/nav/gandalf/api/controllers/WSSAMLTokenController.kt
+++ b/src/main/kotlin/no/nav/gandalf/api/controllers/WSSAMLTokenController.kt
@@ -57,7 +57,7 @@ class WSSAMLTokenController(
                         ResponseEntity.status(HttpStatus.OK).body(wsReq.getResponse(samlToken!!))
                     } catch (e: Throwable) {
                         ApplicationMetric.wsSAMLTokenNotOk.increment()
-                        ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Validation failed" + e.message)
+                        ResponseEntity.status(HttpStatus.BAD_REQUEST).body("SAML validation failed")
                     }
                 }
                 wsReq.isIssueSamlFromUNT -> {

--- a/src/main/kotlin/no/nav/gandalf/xml/SecureXml.kt
+++ b/src/main/kotlin/no/nav/gandalf/xml/SecureXml.kt
@@ -1,6 +1,7 @@
 package no.nav.gandalf.xml
 
 import org.xml.sax.EntityResolver
+import org.xml.sax.SAXException
 import javax.xml.XMLConstants
 import javax.xml.crypto.URIDereferencer
 import javax.xml.crypto.URIReference
@@ -54,6 +55,6 @@ internal object SecureXml {
 
     fun rejectingEntityResolver(): EntityResolver =
         EntityResolver { _, _ ->
-            throw IllegalArgumentException("External XML entities are not allowed")
+            throw SAXException("External XML entities are not allowed")
         }
 }

--- a/src/main/kotlin/no/nav/gandalf/xml/SecureXml.kt
+++ b/src/main/kotlin/no/nav/gandalf/xml/SecureXml.kt
@@ -26,6 +26,8 @@ internal object SecureXml {
     fun documentBuilderFactory(): DocumentBuilderFactory =
         DocumentBuilderFactory.newInstance().apply {
             isNamespaceAware = true
+            isXIncludeAware = false
+            isExpandEntityReferences = false
             setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
             setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
             setFeature("http://xml.org/sax/features/external-general-entities", false)

--- a/src/main/kotlin/no/nav/gandalf/xml/SecureXml.kt
+++ b/src/main/kotlin/no/nav/gandalf/xml/SecureXml.kt
@@ -1,0 +1,59 @@
+package no.nav.gandalf.xml
+
+import org.xml.sax.EntityResolver
+import javax.xml.XMLConstants
+import javax.xml.crypto.URIDereferencer
+import javax.xml.crypto.URIReference
+import javax.xml.crypto.URIReferenceException
+import javax.xml.crypto.XMLCryptoContext
+import javax.xml.crypto.dsig.XMLSignatureFactory
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.TransformerFactory
+
+/**
+ * Central boundary for XML security configuration.
+ *
+ * RED ZONE: The feature and attribute configuration here is security-critical.
+ * It must fail closed: XML from callers may never cause local or network access.
+ */
+internal object SecureXml {
+    fun documentBuilder() =
+        documentBuilderFactory().newDocumentBuilder().apply {
+            setEntityResolver(rejectingEntityResolver())
+        }
+
+    fun documentBuilderFactory(): DocumentBuilderFactory =
+        DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = true
+            setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            setFeature("http://xml.org/sax/features/external-general-entities", false)
+            setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+            setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+            setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+        }
+
+    fun transformerFactory(): TransformerFactory =
+        TransformerFactory.newInstance().apply {
+            setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+            setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+            setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "")
+        }
+
+    fun sameDocumentUriDereferencer(): URIDereferencer {
+        val providerDereferencer = XMLSignatureFactory.getInstance("DOM").uriDereferencer
+        return URIDereferencer { reference: URIReference, context: XMLCryptoContext ->
+            val uri = reference.uri
+            if (uri == null || !uri.startsWith("#")) {
+                throw URIReferenceException("Only same-document XML signature references are allowed")
+            }
+            providerDereferencer.dereference(reference, context)
+        }
+    }
+
+    fun rejectingEntityResolver(): EntityResolver =
+        EntityResolver { _, _ ->
+            throw IllegalArgumentException("External XML entities are not allowed")
+        }
+}

--- a/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
@@ -71,6 +71,20 @@ class SamlObjectTest {
     }
 
     @Test
+    fun `rejects signature reference without URI during validation`() {
+        val missingReferenceUri = getSamlToken().replace("URI=\"#SAML-4161a46a-ebc3-403f-9d3d-4eff65a070ae\"", "")
+        val samlObject = SamlObject(ZonedDateTime.parse("2019-05-14T08:47:04.255Z"))
+        samlObject.read(missingReferenceUri)
+
+        val exception =
+            assertThrows<OAuthException> {
+                samlObject.validate(keySelector)
+            }
+
+        assertTrue(exception.message!!.contains("non-local reference"))
+    }
+
+    @Test
     fun `validates SAML token with same-document signature reference`() {
         val notOnOrAfter = ZonedDateTime.parse("2019-05-14T08:47:06.255Z")
         val now = notOnOrAfter.minusSeconds(2)

--- a/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
@@ -10,6 +10,7 @@ import org.junit.Assert
 import org.junit.Assert.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.annotation.DirtiesContext
@@ -41,6 +42,28 @@ class SamlObjectTest {
         assertTrue(samlObj.consumerId != null && samlObj.consumerId.equals("srvsecurity-token-"))
         assertTrue(samlObj.identType != null && samlObj.identType.equals("Systemressurs"))
         assertTrue(samlObj.authenticationLevel != null && samlObj.authenticationLevel.equals("0"))
+    }
+
+    @Test
+    fun `rejects SAML containing a doctype`() {
+        assertThrows<Exception> {
+            SamlObject().read("<!DOCTYPE Assertion><Assertion/>")
+        }
+    }
+
+    @Test
+    fun `rejects non-fragment signature reference during validation`() {
+        val externalReference =
+            getSamlToken().replace(
+                "URI=\"#SAML-4161a46a-ebc3-403f-9d3d-4eff65a070ae\"",
+                "URI=\"https://example.invalid/reference.xml\"",
+            )
+        val samlObject = SamlObject(ZonedDateTime.parse("2019-05-14T08:47:04.255Z"))
+        samlObject.read(externalReference)
+
+        assertThrows<Exception> {
+            samlObject.validate(keySelector)
+        }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
@@ -61,9 +61,12 @@ class SamlObjectTest {
         val samlObject = SamlObject(ZonedDateTime.parse("2019-05-14T08:47:04.255Z"))
         samlObject.read(externalReference)
 
-        assertThrows<Exception> {
-            samlObject.validate(keySelector)
-        }
+        val exception =
+            assertThrows<OAuthException> {
+                samlObject.validate(keySelector)
+            }
+
+        assertTrue(exception.message!!.contains("non-local reference"))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
+import org.xml.sax.SAXException
 import java.time.ZonedDateTime
 import javax.xml.crypto.KeySelector
 
@@ -46,7 +47,7 @@ class SamlObjectTest {
 
     @Test
     fun `rejects SAML containing a doctype`() {
-        assertThrows<Exception> {
+        assertThrows<SAXException> {
             SamlObject().read("<!DOCTYPE Assertion><Assertion/>")
         }
     }

--- a/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/accesstoken/SamlObjectTest.kt
@@ -67,7 +67,7 @@ class SamlObjectTest {
     }
 
     @Test
-    fun `Read And Validate SAML Token`() {
+    fun `validates SAML token with same-document signature reference`() {
         val notOnOrAfter = ZonedDateTime.parse("2019-05-14T08:47:06.255Z")
         val now = notOnOrAfter.minusSeconds(2)
         assertDoesNotThrow {

--- a/src/test/kotlin/no/nav/gandalf/api/WSSAMLTokenControllerTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/WSSAMLTokenControllerTest.kt
@@ -59,6 +59,19 @@ class WSSAMLTokenControllerTest : SpringBootWireMockSetup() {
     }
 
     @Test
+    fun `SAML - WS - rejects request containing a doctype`() {
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post(WS_SAMLTOKEN)
+                    .with(SecurityMockMvcRequestPostProcessors.anonymous())
+                    .contentType(MediaType.TEXT_XML)
+                    .content("<!DOCTYPE Envelope><Envelope/>"),
+            ).andExpect(MockMvcResultMatchers.status().isBadRequest)
+            .andExpect(MockMvcResultMatchers.content().string("Invalid XML request"))
+    }
+
+    @Test
     fun `SAML - WS - isExchangeOidcToSaml`() {
         val xmlReq = setupOIDCtoSAMLRequest("srvPDP", "password", issuer)
         mvc

--- a/src/test/kotlin/no/nav/gandalf/api/WSSAMLTokenControllerTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/WSSAMLTokenControllerTest.kt
@@ -61,13 +61,15 @@ class WSSAMLTokenControllerTest : SpringBootWireMockSetup() {
 
     @Test
     fun `SAML - WS - rejects request containing a doctype`() {
+        val xmlRequest = "<!DOCTYPE soap:Envelope>" + getSamlRequest("srvPDP", "password")
+
         mvc
             .perform(
                 MockMvcRequestBuilders
                     .post(WS_SAMLTOKEN)
                     .with(SecurityMockMvcRequestPostProcessors.anonymous())
                     .contentType(MediaType.TEXT_XML)
-                    .content("<!DOCTYPE Envelope><Envelope/>"),
+                    .content(xmlRequest),
             ).andExpect(MockMvcResultMatchers.status().isBadRequest)
             .andExpect(MockMvcResultMatchers.content().string("Invalid XML request"))
     }

--- a/src/test/kotlin/no/nav/gandalf/api/WSSAMLTokenControllerTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/WSSAMLTokenControllerTest.kt
@@ -8,6 +8,7 @@ import no.nav.gandalf.accesstoken.AccessTokenIssuer
 import no.nav.gandalf.utils.WS_SAMLTOKEN
 import no.nav.gandalf.utils.getOidcToSamlRequest
 import no.nav.gandalf.utils.getSamlRequest
+import no.nav.gandalf.utils.getSamlToken
 import no.nav.gandalf.utils.getValidateSamlRequest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -101,6 +102,21 @@ class WSSAMLTokenControllerTest : SpringBootWireMockSetup() {
             .andExpect(MockMvcResultMatchers.content().contentType("text/xml;charset=UTF-8"))
         // TODO Validate response
         // .andExpect(MockMvcResultMatchers.xpath("/*/soapenv:Body/").exists())
+    }
+
+    @Test
+    fun `SAML - WS - hides SAML validation errors`() {
+        val xmlReq = getValidateSamlRequest("srvPDP", "password", getSamlToken())
+
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post(WS_SAMLTOKEN)
+                    .with(SecurityMockMvcRequestPostProcessors.anonymous())
+                    .contentType(MediaType.TEXT_XML)
+                    .content(xmlReq),
+            ).andExpect(MockMvcResultMatchers.status().isBadRequest)
+            .andExpect(MockMvcResultMatchers.content().string("SAML validation failed"))
     }
 
     @Disabled("MockkStatic is disabled on newer java versions")

--- a/src/test/kotlin/no/nav/gandalf/api/WSTrustRequestTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/WSTrustRequestTest.kt
@@ -44,8 +44,10 @@ class WSTrustRequestTest {
 
     @Test
     fun `rejects WS-Trust request containing a doctype`() {
+        val xmlRequest = "<!DOCTYPE soapenv:Envelope>" + getSamlRequest(username, password)
+
         assertThrows<IllegalArgumentException> {
-            WSTrustRequest().read("<!DOCTYPE Envelope><Envelope/>")
+            WSTrustRequest().read(xmlRequest)
         }
     }
 

--- a/src/test/kotlin/no/nav/gandalf/api/WSTrustRequestTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/api/WSTrustRequestTest.kt
@@ -10,6 +10,7 @@ import no.nav.gandalf.utils.getSamlRequest
 import no.nav.gandalf.utils.getValidateSamlRequest
 import org.junit.Assert
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -39,6 +40,13 @@ class WSTrustRequestTest {
         val wsReq = WSTrustRequest()
         wsReq.read(xmlReq)
         Assert.assertTrue(wsReq.isIssueSamlFromUNT)
+    }
+
+    @Test
+    fun `rejects WS-Trust request containing a doctype`() {
+        assertThrows<IllegalArgumentException> {
+            WSTrustRequest().read("<!DOCTYPE Envelope><Envelope/>")
+        }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
@@ -12,6 +12,14 @@ import javax.xml.transform.stream.StreamSource
 
 class SecureXmlSecurityTest {
     @Test
+    fun `disables XInclude and entity expansion`() {
+        val factory = SecureXml.documentBuilderFactory()
+
+        assertFalse(factory.isXIncludeAware)
+        assertFalse(factory.isExpandEntityReferences)
+    }
+
+    @Test
     fun `rejects XML containing a doctype`() {
         val xmlWithDoctype = """<!DOCTYPE root><root/>"""
 

--- a/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.xml.crypto.URIReference
 import javax.xml.crypto.URIReferenceException
 import javax.xml.crypto.dom.DOMCryptoContext
+import javax.xml.transform.stream.StreamSource
 
 class SecureXmlSecurityTest {
     @Test
@@ -31,6 +32,38 @@ class SecureXmlSecurityTest {
         }
 
         check(!resolverCalled.get())
+    }
+
+    @Test
+    fun `rejects external general entities`() {
+        assertThrows<Exception> {
+            SecureXml.documentBuilder().parse(
+                "<!DOCTYPE root [<!ENTITY entity SYSTEM \"https://example.invalid/entity\">]><root>&entity;</root>".byteInputStream(),
+            )
+        }
+    }
+
+    @Test
+    fun `rejects external parameter entities`() {
+        assertThrows<Exception> {
+            SecureXml.documentBuilder().parse(
+                "<!DOCTYPE root [<!ENTITY % entity SYSTEM \"https://example.invalid/entity\">%entity;]><root/>".byteInputStream(),
+            )
+        }
+    }
+
+    @Test
+    fun `rejects external XSLT imports`() {
+        val stylesheet =
+            """
+            <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                <xsl:import href="https://example.invalid/stylesheet.xsl"/>
+            </xsl:stylesheet>
+            """.trimIndent()
+
+        assertThrows<Exception> {
+            SecureXml.transformerFactory().newTransformer(StreamSource(stylesheet.reader()))
+        }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
@@ -1,0 +1,49 @@
+package no.nav.gandalf.xml
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.xml.crypto.URIReference
+import javax.xml.crypto.URIReferenceException
+import javax.xml.crypto.dom.DOMCryptoContext
+
+class SecureXmlSecurityTest {
+    @Test
+    fun `rejects XML containing a doctype`() {
+        val xmlWithDoctype = """<!DOCTYPE root><root/>"""
+
+        assertThrows<Exception> {
+            SecureXml.documentBuilderFactory().newDocumentBuilder().parse(xmlWithDoctype.byteInputStream())
+        }
+    }
+
+    @Test
+    fun `rejects a doctype before resolving its external entity`() {
+        val resolverCalled = AtomicBoolean(false)
+        val builder = SecureXml.documentBuilderFactory().newDocumentBuilder()
+        builder.setEntityResolver { _, _ ->
+            resolverCalled.set(true)
+            null
+        }
+
+        assertThrows<Exception> {
+            builder.parse("<!DOCTYPE root SYSTEM \"https://example.invalid/test.dtd\"><root/>".byteInputStream())
+        }
+
+        check(!resolverCalled.get())
+    }
+
+    @Test
+    fun `rejects non-fragment XML signature references`() {
+        val reference =
+            object : URIReference {
+                override fun getURI() = "https://example.invalid/reference.xml"
+
+                override fun getType() = null
+            }
+
+        assertThrows<URIReferenceException> {
+            SecureXml.sameDocumentUriDereferencer().dereference(reference, object : DOMCryptoContext() {})
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
@@ -1,5 +1,6 @@
 package no.nav.gandalf.xml
 
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.xml.sax.SAXException
@@ -32,7 +33,7 @@ class SecureXmlSecurityTest {
             builder.parse("<!DOCTYPE root SYSTEM \"https://example.invalid/test.dtd\"><root/>".byteInputStream())
         }
 
-        check(!resolverCalled.get())
+        assertFalse(resolverCalled.get(), "External entity resolver must not be called")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
@@ -30,36 +30,21 @@ class SecureXmlSecurityTest {
 
     @Test
     fun `rejects a doctype before resolving its external entity`() {
-        val resolverCalled = AtomicBoolean(false)
-        val builder = SecureXml.documentBuilderFactory().newDocumentBuilder()
-        builder.setEntityResolver { _, _ ->
-            resolverCalled.set(true)
-            null
-        }
-
-        assertThrows<SAXException> {
-            builder.parse("<!DOCTYPE root SYSTEM \"https://example.invalid/test.dtd\"><root/>".byteInputStream())
-        }
-
-        assertFalse(resolverCalled.get(), "External entity resolver must not be called")
+        assertRejectedWithoutResolving("<!DOCTYPE root SYSTEM \"https://example.invalid/test.dtd\"><root/>")
     }
 
     @Test
     fun `rejects external general entities`() {
-        assertThrows<Exception> {
-            SecureXml.documentBuilder().parse(
-                "<!DOCTYPE root [<!ENTITY entity SYSTEM \"https://example.invalid/entity\">]><root>&entity;</root>".byteInputStream(),
-            )
-        }
+        assertRejectedWithoutResolving(
+            "<!DOCTYPE root [<!ENTITY entity SYSTEM \"https://example.invalid/entity\">]><root>&entity;</root>",
+        )
     }
 
     @Test
     fun `rejects external parameter entities`() {
-        assertThrows<Exception> {
-            SecureXml.documentBuilder().parse(
-                "<!DOCTYPE root [<!ENTITY % entity SYSTEM \"https://example.invalid/entity\">%entity;]><root/>".byteInputStream(),
-            )
-        }
+        assertRejectedWithoutResolving(
+            "<!DOCTYPE root [<!ENTITY % entity SYSTEM \"https://example.invalid/entity\">%entity;]><root/>",
+        )
     }
 
     @Test
@@ -88,5 +73,20 @@ class SecureXmlSecurityTest {
         assertThrows<URIReferenceException> {
             SecureXml.sameDocumentUriDereferencer().dereference(reference, object : DOMCryptoContext() {})
         }
+    }
+
+    private fun assertRejectedWithoutResolving(xml: String) {
+        val resolverCalled = AtomicBoolean(false)
+        val builder = SecureXml.documentBuilderFactory().newDocumentBuilder()
+        builder.setEntityResolver { _, _ ->
+            resolverCalled.set(true)
+            null
+        }
+
+        assertThrows<SAXException> {
+            builder.parse(xml.byteInputStream())
+        }
+
+        assertFalse(resolverCalled.get(), "External entity resolver must not be called")
     }
 }

--- a/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
+++ b/src/test/kotlin/no/nav/gandalf/xml/SecureXmlSecurityTest.kt
@@ -2,6 +2,7 @@ package no.nav.gandalf.xml
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.xml.sax.SAXException
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.xml.crypto.URIReference
 import javax.xml.crypto.URIReferenceException
@@ -13,7 +14,7 @@ class SecureXmlSecurityTest {
     fun `rejects XML containing a doctype`() {
         val xmlWithDoctype = """<!DOCTYPE root><root/>"""
 
-        assertThrows<Exception> {
+        assertThrows<SAXException> {
             SecureXml.documentBuilderFactory().newDocumentBuilder().parse(xmlWithDoctype.byteInputStream())
         }
     }
@@ -27,7 +28,7 @@ class SecureXmlSecurityTest {
             null
         }
 
-        assertThrows<Exception> {
+        assertThrows<SAXException> {
             builder.parse("<!DOCTYPE root SYSTEM \"https://example.invalid/test.dtd\"><root/>".byteInputStream())
         }
 


### PR DESCRIPTION
## Summary
- centralize fail-closed DOM parsing and transformation configuration
- reject missing or non-local XMLDSig references before cryptographic validation, with a dereferencer as defense in depth
- return generic 400 responses for malformed WS-Trust XML and failed SAML validation
- add local Docker Compose support for the embedded LDAP setup
- deploy `release/**` branches to both T4 and the standard dev environment, never prod
- document release verification steps

## Regression coverage
- valid WS-Trust requests prefixed with `DOCTYPE` are rejected at parser and endpoint layers
- external general and parameter entities are rejected
- the entity resolver is asserted not to be invoked
- external XSLT imports are rejected
- valid same-document XMLDSig references remain accepted
- missing and non-fragment XMLDSig references are rejected before signature validation

## Verification
- `./gradlew ktlintCheck test`
- local Docker Compose starts successfully; valid WS-Trust returns 200 and `DOCTYPE` returns generic 400
- `trivy repo . --scanners secret --severity HIGH,CRITICAL`

## Security
- No exploit payloads, callback addresses, or environment data are included.